### PR TITLE
Improve pools options

### DIFF
--- a/python/deadlinesubmissionsettings/app.py
+++ b/python/deadlinesubmissionsettings/app.py
@@ -193,8 +193,11 @@ class App(QtWidgets.QWidget):
     def create_pools_options(self):
         pools = ["-"]
         pools.extend(lib.get_pool_list())
-        for pool in pools:
+
+        for pool in pools[1:]:
             self.primary_pool.addItem(pool)
+
+        for pool in pools:
             self.secondary_pool.addItem(pool)
 
     def create_groups_options(self):

--- a/python/deadlinesubmissionsettings/app.py
+++ b/python/deadlinesubmissionsettings/app.py
@@ -191,7 +191,8 @@ class App(QtWidgets.QWidget):
             self.machine_list.addItem(name)
 
     def create_pools_options(self):
-        pools = lib.get_pool_list()
+        pools = ["-"]
+        pools.extend(lib.get_pool_list())
         for pool in pools:
             self.primary_pool.addItem(pool)
             self.secondary_pool.addItem(pool)
@@ -287,9 +288,9 @@ class App(QtWidgets.QWidget):
 
         pools = [i for i in settings.get("pools", "").split(";") if i != ""]
         if not pools:
-            pools = ["none", "none"]
+            pools = ["none", "-"]
         elif len(pools) == 1:
-            pools.append("none")
+            pools.append("-")
 
         primary_pool, secondary_pool = pools
 


### PR DESCRIPTION
Added 'empty' entry for secondary pools to ensure the user(s) don't add the default pool `none` to the job. 

__Explanation:__
When checking the Job Poperties the `Primary pool` is `none` which is the default and the `Secondary Pool` is an empty entrie in the combo box. This means that `none` is not `none` but `all` or you could say that `none` is `no specific pool`. All machines are assigned to `none` by default.

__Example:__
Primary pool: redshift
Secondary pool: none

In this example we tell that all slaves which have are assigned to `redshift` and to `none` can render this job. This will cause a cycle of attempts which can fail because the machines don't have the correct requirements.


This PR is in conjuntion with: https://github.com/Colorbleed/colorbleed-config/pull/136
